### PR TITLE
Don't assert on taken not a branch when inst is ecall

### DIFF
--- a/stf-inc/stf_branch_reader.hpp
+++ b/stf-inc/stf_branch_reader.hpp
@@ -125,7 +125,7 @@ namespace stf {
                 const bool skip_item = skippingEnabled_();
                 countSkippedInst_(skip_item);
 
-                if(!STFBranchDecoder::decode(getInitialIEM(), inst_rec, branch)) {
+                if(STF_EXPECT_TRUE(!STFBranchDecoder::decode(getInitialIEM(), inst_rec, branch))) {
                     // ecall opcode 0x73 will be seen as taken but non-branch
                     stf_assert(!(branch.isTaken() && inst_rec.getOpcode() != 0x73), "Branch was marked taken but also didn't decode as a branch");
                     delegates::STFBranchDelegate::reset_(branch);

--- a/stf-inc/stf_branch_reader.hpp
+++ b/stf-inc/stf_branch_reader.hpp
@@ -125,8 +125,9 @@ namespace stf {
                 const bool skip_item = skippingEnabled_();
                 countSkippedInst_(skip_item);
 
-                if(STF_EXPECT_TRUE(!STFBranchDecoder::decode(getInitialIEM(), inst_rec, branch))) {
-                    stf_assert(!branch.isTaken(), "Branch was marked taken but also didn't decode as a branch");
+                if(!STFBranchDecoder::decode(getInitialIEM(), inst_rec, branch)) {
+                    // ecall opcode 0x73 will be seen as taken but non-branch
+                    stf_assert(!(branch.isTaken() && inst_rec.getOpcode() != 0x73), "Branch was marked taken but also didn't decode as a branch");
                     delegates::STFBranchDelegate::reset_(branch);
                     resetOperandMaps_();
                     return false;


### PR DESCRIPTION
Branch reader previously asserted on ecall instructions in traces since ecall decode as taken but not branches.